### PR TITLE
Submitter discount

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -23,6 +23,12 @@
             = time_ago_in_words(event.closes_at)
             left
           to submit your proposal!
+        %h2.h4.strong About a ticket coupon
+        %p
+          All people submitting a proposal can get a ticket coupon! Please wait to purchase the ticket until your proposal is adopted or not. If proposal is adopted, you can get an 100% discount coupon. Even not, you can get coupon at SuperEarlyBird price. Please purchase the ticket by using a coupon from
+          = link_to "Doorkeeper's event page", 'https://rubykaigi.doorkeeper.jp/events/upcoming'
+          \.
+
     - if event.proposals.count > 5
       .stats
         %h2 CFP Stats


### PR DESCRIPTION
CFP提出者のチケット割引メッセージを追加しました。チケット購入ページのリンク先はまだ存在しないため、公開した後変更します。
ただディスカウント方法はイベントによって変わる可能性があるので、`events`の`guidelines`や`policies`に入れたほうがいいのかなと思いましたが、branchが2016用だったのでviewに書きました。
