### PR TITLE
update accept / reject email language

### DIFF
--- a/app/views/organizer/proposal_mailer/accept_email.md.erb
+++ b/app/views/organizer/proposal_mailer/accept_email.md.erb
@@ -3,14 +3,19 @@
  <% else %>
     Congratulations! We'd love to include your talk, <%= @proposal.title %>, at <%= @event.name %>.
 
-    TO CONFIRM that you're still willing and able to present this talk, please visit the <%= @proposal.confirm_link %> .
+    PLEASE KEEP THIS QUIET (no tweeting!) until your talk is announced as part of our program. We are expecting to have the whole program published by the end of this month <%= raise 'this month?' %> on our Program page -- we'll tweet about it from @rubykaigi once it's live. When you see your talk announced on our Program page, you can let everyone know that you'll be speaking!
 
-    If you already purchased a ticket for RubyKaigi, please email us at 2016@rubykaigi.org and we will happily refund your ticket.
+    TO CONFIRM that you're still willing and able to present the above talk, please do two things:
+
+    1. Click <%= @proposal.confirm_link %> and click the 'Confirm' button.
+
+    2. Once you have confirmed, please use this link <%= raise 'fill think link' %> to book your complimentary Speaker's pass. If you already have purchased a ticket to RubyKaigi, you should still book your Speaker ticket, and then email 2016@rubykaigi.org to obtain a refund for your paid ticket.
+
+    Please note: if your accepted talk has more than one speaker, each speaker needs his or her own complimentary speaker's pass.
 
     TO DECLINE (if you're no longer able to give this talk), please visit the <%= @proposal.confirm_link %>, and click the 'Withdraw Proposal' button.
 
-    In the meantime, let us know if you have any questions. We're looking forward to seeing you there!
+    In the meantime, be sure to let us know if you have any questions. We're looking forward to seeing you there!
 
-    The <%= @event.name %> Organizers
-
+    The <%= @event.name %> Committee
 <% end %>

--- a/app/views/organizer/proposal_mailer/reject_email.md.erb
+++ b/app/views/organizer/proposal_mailer/reject_email.md.erb
@@ -2,13 +2,13 @@
   <%= Organizer::ProposalMailerTemplate.new(@event.reject, @event,
       @proposal, [ :proposal_title ]).render %>
 <% else %>
-    Thank you for your proposal to <%= @event.name %>. Our program committee received many great talk submissions this year, and that's allowed us to put together an exciting program.
+    Thank you for submitting your proposal to <%= @event.name %>. Our Program Committee received a large number of high-quality talk submissions this year. On one hand, that has allowed us to put together a very exciting program.
 
-    As a result of the number of talks submitted, however, we've had to turn down a lot of excellent proposals. I'm sorry to say that we were not able to accept your submission titled, <%= @proposal.title %>, this year. This is always the toughest part knowing that we simply can't fit all the good talks in. We hope that you'll still be able to attend the conference.
+    However, that also means that -- given the sheer number of talks submitted -- we have to decline a lot of excellent proposals. Sadly, that includes your submission -- <%= @proposal.title %>. Knowing that we simply can't fit all the good talks in is always the toughest part of the program selection process.
 
-    If you haven't already purchased a ticket for RubyKaigi, you will be able to get one at the "Super Early Bird" price even if the tickets are sold out. In that case, please email us at 2016@rubykaigi.org for the discount.
+    Our sincere hope is that you will still be able to attend the conference. To that point, we ensure you the chance to get a single RubyKaigi ticket at the "Super Early Bird" price, even if the general pool of tickets sells out. In that case, please email us at 2016@rubykaigi.org for the discount.
 
-    Thanks again for your submission as we really appreciate your willingness to share with the community.
+    Thank you again for your submission. We are truly appreciative of your willingness to share your ideas and efforts with our community.
 
     The <%= @event.name %> Organizers
 


### PR DESCRIPTION
Just got 2 emails from rubyconf this year and found they customized these views.

I don't say we must follow them, but the change is worth reading I think.
