### PR TITLE
Use markdown-compiled values only for drawing contents

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -61,15 +61,15 @@ class ProposalDecorator < ApplicationDecorator
     speaker ? speaker.bio : ''
   end
 
-  def pitch
+  def compiled_pitch
     h.markdown(object.pitch)
   end
 
-  def details
+  def compiled_details
     h.markdown(object.details)
   end
 
-  def abstract
+  def compiled_abstract
     h.markdown(object.abstract)
   end
 

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -15,15 +15,15 @@
 
 %h3 Abstract
 .markdown{ data: { 'field-id' => 'proposal_abstract' } }
-  = proposal.abstract
+  = proposal.compiled_abstract
 
 %h3 Details
 .markdown{ data: { 'field-id' => 'proposal_details' } }
-  = proposal.details
+  = proposal.compiled_details
 
 %h3 Pitch
 .markdown{ data: { 'field-id' => 'proposal_pitch' } }
-  =proposal.pitch
+  =proposal.compiled_pitch
 
   - if proposal.custom_fields.any?
     - proposal.proposal_data[:custom_fields].select do |key,value|

--- a/app/views/proposals/confirm.html.haml
+++ b/app/views/proposals/confirm.html.haml
@@ -17,7 +17,7 @@
         %p.help-block Congratulations! Your talk has been #{proposal.state}. Please ensure the information below is correct.
 
       %h3 Abstract
-      = proposal.abstract
+      = proposal.compiled_abstract
       %h3 Speakers
       = render partial: 'speakers/speaker',
         collection: proposal.speakers, locals: { withdraw: false }


### PR DESCRIPTION
In this pull-request, I fixed the issue that markdown-compiled values appear in text areas when I edit a proposal.

Note that I couldn't check whether all the spec files are passed because I couldn't make my Mac capybara-webkit ready.

<img width="132" alt="screenshot 2017-05-12 10 17 30" src="https://cloud.githubusercontent.com/assets/3959/25982055/404ee232-3714-11e7-9244-8a5be02c7815.png">
