### PR TITLE
Order speakers by first name

### DIFF
--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -24,9 +24,7 @@ module RubyKaigi
       keynotes, speakers = people.partition {|p| KEYNOTES.include? p.first}
       keynotes = keynotes.sort_by {|k, _| KEYNOTES.index k}.to_h
 
-      speakers = {'keynotes' => keynotes.to_h, 'speakers' => speakers.sort_by do |p|
-        p.last['name'].split(" ").last.downcase
-      end.to_h}
+      speakers = {'keynotes' => keynotes.to_h, 'speakers' => speakers.sort_by {|p| p.last['name'].downcase }.to_h}
       speakers.delete 'keynotes' if speakers['keynotes'].empty?
       speakers
     end

--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -24,7 +24,9 @@ module RubyKaigi
       keynotes, speakers = people.partition {|p| KEYNOTES.include? p.first}
       keynotes = keynotes.sort_by {|k, _| KEYNOTES.index k}.to_h
 
-      speakers = {'keynotes' => keynotes.to_h, 'speakers' => speakers.sort_by {|p| p.first.downcase}.to_h}
+      speakers = {'keynotes' => keynotes.to_h, 'speakers' => speakers.sort_by do |p|
+        p.last['name'].gsub(" (@hatappi)", "").split(" ").last.downcase
+      end.to_h}
       speakers.delete 'keynotes' if speakers['keynotes'].empty?
       speakers
     end

--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -25,7 +25,7 @@ module RubyKaigi
       keynotes = keynotes.sort_by {|k, _| KEYNOTES.index k}.to_h
 
       speakers = {'keynotes' => keynotes.to_h, 'speakers' => speakers.sort_by do |p|
-        p.last['name'].gsub(" (@hatappi)", "").split(" ").last.downcase
+        p.last['name'].split(" ").last.downcase
       end.to_h}
       speakers.delete 'keynotes' if speakers['keynotes'].empty?
       speakers


### PR DESCRIPTION
@asonas https://github.com/ruby-no-kai/rubykaigi2018/pull/169 でスピーカーの並び順をorder by last_name に変更する対応を入れてもらったんですが、やっぱり first_name 順にしたいです。

察するに、first nameだと "Yoh" も "Yurie" も後ろのほうに来ちゃうから大して変わって見えない、ってことで last nameにしてみたんだろうとは思うんですが、なんか、このメンツの並びでlast nameってあまりにも意識しない属性すぎて、それがorder byのキーになってるのがだいぶ不自然な感じがしてしっくりこない感じです。
やっぱりPattersonさんじゃなくてAaronだし、HodelさんじゃなくてEricだし、LeeさんじゃなくてTerenceだし、MakarovさんじゃなくてVladなわけで。

女性が比較的下の方に固まっちゃう問題は、とは言え "Yuta" と "Yusuke" と "Yuichiro" が居るし、"Emma Haruka" は下の方じゃないからまぁ大丈夫なんじゃないでしょうか。