### PR TITLE
Add session id to KEYNOTE_SESSIONS

### DIFF
--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -1,7 +1,7 @@
 module RubyKaigi
   # 2018
   KEYNOTES = %w(yukihiro_matz ktou eregontp)
-  KEYNOTE_SESSIONS = [125, 89, 126, 187, 197, 138]  # matz, justin, nalsh, nobu, matz, vnmakarov
+  KEYNOTE_SESSIONS = [125, 89, 126, 187, 197, 138, 215, 235, 258]  # matz, justin, nalsh, nobu, matz, vnmakarov, matz, kou, eregon
 
   DISCUSSION_SESSIONS = [127, 172].freeze  # committers, committers
   LT_SESSIONS = [159].freeze  # LT


### PR DESCRIPTION
yamlを生成する段階でIDを設定してないと[`type`が変更されないようなので](https://github.com/ruby-no-kai/cfp-app/blob/rubykaigi2018/lib/ruby_kaigi.rb#L52)追加しました