### PR TITLE
Order sessions by room.grid_position instead of room_id

### DIFF
--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -42,10 +42,10 @@ module RubyKaigi
     def self.schedule(event)
       first_date = event.start_date.to_date
 
-      result = event.sessions.includes(proposal: {speakers: {person: :services}}).group_by(&:conference_day).sort_by {|day, _| day}.each_with_object({}) do |(day, sessions), schedule|
+      result = event.sessions.includes([{proposal: {speakers: {person: :services}}}, :room]).group_by(&:conference_day).sort_by {|day, _| day}.each_with_object({}) do |(day, sessions), schedule|
         events = sessions.group_by {|s| [s.start_time, s.end_time]}.sort_by {|(start_time, end_time), _| [start_time, end_time]}.map do |(start_time, end_time), sessions_per_time|
           event = {'type' => nil, 'begin' => start_time.strftime('%H:%M'), 'end' => end_time.strftime('%H:%M')}
-          talks = sessions_per_time.sort_by(&:room_id).each_with_object({}) do |session, h|
+          talks = sessions_per_time.sort_by {|s| s.room&.grid_position }.each_with_object({}) do |session, h|
             h[session.room.room_number] = session.proposal.speakers.first.person.social_account if session.proposal
           end
           if talks.any?


### PR DESCRIPTION
https://github.com/ruby-no-kai/rubykaigi2018/issues/223 なんですが、現在、2018のタイムテーブルでは、部屋の表示順が大、小、中の順になってしまっています。
何故こうなってしまってるかというと、cfp-appのスケジュール表示機能上では rooms.grid_position 順で表示されてたんですが、schedule.yml 生成スクリプトではこのカラムを使わずに room_id でソートしてたから、なんですね。
今までは Room を作る時に注意深くデカい順にデータを投入してたので問題になってなかったんですが、今回はidがメイン、萩、橘、の順になってしまったので、cfp-app上の表示とyamlの順番が違ってしまったようです。これはひどい罠ですね。

ということで、これを機に今後は grid_position の値を見るようにしました。

/cc @asonas 