### PR TITLE
Add LT id

### DIFF
--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -4,7 +4,7 @@ module RubyKaigi
   KEYNOTE_SESSIONS = [125, 89, 126, 187, 197, 138, 215, 235, 258]  # matz, justin, nalsh, nobu, matz, vnmakarov, matz, kou, eregon
 
   DISCUSSION_SESSIONS = [127, 172].freeze  # committers, committers
-  LT_SESSIONS = [159].freeze  # LT
+  LT_SESSIONS = [159, 233].freeze  # LT
 
   module CfpApp
     def self.speakers(event)


### PR DESCRIPTION
[eventのtypeがltにならないと](https://github.com/ruby-no-kai/rubykaigi2018/blob/master/source/2018/partials/_schedule-table.html.haml#L26)タイムテーブル上でリンクにならないようだったのでLTのidを追加しました。

https://cfp.rubykaigi.org/organizer/events/7/sessions