### PR TITLE
Ignore duplicated speakers

### DIFF
--- a/lib/ruby_kaigi.rb
+++ b/lib/ruby_kaigi.rb
@@ -12,6 +12,7 @@ module RubyKaigi
         person = sp.person
         tw = person.services.detect {|s| s.provider == 'twitter'}&.account_name
         gh = person.services.detect {|s| s.provider == 'github'}&.account_name
+        next if tw == "ktou2" || tw == "mrkn2"
         id = tw || gh
         bio = if sp.bio.present? && (sp.bio != 'N/A')
           sp.bio


### PR DESCRIPTION
対応が漏れていたので対象のアカウントをyamlに取り込まないようにしました。

## mrkn

<img width="554" alt="2018-06-02 12 34 33" src="https://user-images.githubusercontent.com/630181/40870041-6334599e-6661-11e8-8cd5-a90a9272742b.png">

## ktou

<img width="1118" alt="2018-06-02 12 34 46" src="https://user-images.githubusercontent.com/630181/40870043-67142f8a-6661-11e8-9825-639d0d60d8bf.png">
<img width="273" alt="2018-06-02 12 34 53" src="https://user-images.githubusercontent.com/630181/40870042-66ec9f24-6661-11e8-872f-e92fb4a6e60b.png">

本番にはそれぞれ "ktou2"と"mrkn2"でアカウントを登録してるのでこの2つのアカウントを無視するようにしました。

```
irb(main):009:0> Person.where(name: "Kouhei Sutou").last.services.map{ |s| s.account_name }
  Person Load (1.1ms)  SELECT  "people".* FROM "people" WHERE "people"."name" = $1  ORDER BY "people"."id" DESC LIMIT 1  [["name", "Kouhei Sutou"]]
  Service Load (0.7ms)  SELECT "services".* FROM "services" WHERE "services"."person_id" = $1  [["person_id", 587]]
=> ["ktou2"]
irb(main):010:0> Person.where(name: "Kenta Murata").last.services.map{ |s| s.account_name }
  Person Load (1.1ms)  SELECT  "people".* FROM "people" WHERE "people"."name" = $1  ORDER BY "people"."id" DESC LIMIT 1  [["name", "Kenta Murata"]]
  Service Load (1.0ms)  SELECT "services".* FROM "services" WHERE "services"."person_id" = $1  [["person_id", 588]]
=> ["mrkn2"]
```