### PR TITLE
Let `Event.recent` scope actually do what it's meant to do

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,7 +21,7 @@ class Event < ActiveRecord::Base
   serialize :custom_fields, Array
 
 
-  scope :recent, -> { order('name ASC') }
+  scope :recent, -> { order('name DESC') }
   scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current).order('closes_at ASC') }
 
   validates :name, :contact_email, presence: true


### PR DESCRIPTION
せっかく @shyouhei さんからいただいた #18 ですが、なんと Event に用意されてるscopeがどう見てもバグってて、その名に反して古い順に返ってくる定義になってました。アメリカ人でもそういう間違いをするんですね。

ということで逆順にします。
これで影響を受ける箇所はメニューのdropdownたちと、あと /events ページの並び順ぐらいなような気がしてます。