### PR TITLE
Let us rate within (1..10)

### DIFF
--- a/app/views/shared/proposals/_rating_form.html.haml
+++ b/app/views/shared/proposals/_rating_form.html.haml
@@ -2,7 +2,7 @@
   = form_for [:reviewer, event, proposal, rating], remote: true do |f|
     .form-group
       = f.label :score, "Rating"
-      = f.select :score, (1..5).to_a, {include_blank: true}, {class: 'form-control', onchange: '$(this).trigger("submit.rails");', disabled: proposal.withdrawn?}
+      = f.select :score, (1..10).to_a, {include_blank: true}, {class: 'form-control', onchange: '$(this).trigger("submit.rails");', disabled: proposal.withdrawn?}
 - unless rating.new_record?
   %dl.dl-horizontal.ratings_list
     %dt.text-success Average rating:


### PR DESCRIPTION
2019LTから、採点を10点満点にしてみたいです。
これで、今までなら「4.5点」とか「限りなく4に近い3とか」言いながらつけてたあたりの微妙なニュアンスを数値化できるようになります。

なお、採点フォームのハテナボックスを叩くと出てくるRating Guideが実態とは乖離することになりますが、まあたぶん誰も参考にしてないだろうから気にしないことにします。