### PR TITLE
Restore github_uid and twitter_uid from the v1 DB

### DIFF
--- a/app/decorators/speaker_decorator.rb
+++ b/app/decorators/speaker_decorator.rb
@@ -15,8 +15,8 @@ class SpeakerDecorator < ApplicationDecorator
   end
 
   def link_to_github
-    if user.provider == 'github'
-      uname = github_uid_to_uname user.uid
+    if user.github_uid
+      uname = github_uid_to_uname user.github_uid
       h.link_to "@#{uname}", "https://github.com/#{uname}", target: '_blank'
     else
       'none'
@@ -31,8 +31,8 @@ class SpeakerDecorator < ApplicationDecorator
   end
 
   def link_to_twitter
-    if user.provider == 'twitter'
-      uname = twitter_uid_to_uname user.uid
+    if user.twitter_uid
+      uname = twitter_uid_to_uname user.twitter_uid
       h.link_to "@#{uname}", "https://twitter.com/#{uname}", target: '_blank'
     else
       'none'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,7 @@ end
 #  created_at             :datetime
 #  updated_at             :datetime
 #  github_uid             :string
+#  twitter_uid            :string
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,6 +169,7 @@ end
 #  remember_created_at    :datetime
 #  created_at             :datetime
 #  updated_at             :datetime
+#  github_uid             :string
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,14 @@ class User < ApplicationRecord
     end
   end
 
+  def github_uid
+    self[:github_uid] || (uid if (provider == 'github'))
+  end
+
+  def twitter_uid
+    self[:twitter_uid] || (uid if(provider == 'twitter'))
+  end
+
   def check_pending_invite_email
     if pending_invite_email.present? && pending_invite_email == email
       skip_confirmation!

--- a/db/migrate/20200109165645_add_github_uid_to_users.rb
+++ b/db/migrate/20200109165645_add_github_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddGithubUidToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :github_uid, :string
+  end
+end

--- a/db/migrate/20200109170101_add_twitter_uid_to_users.rb
+++ b/db/migrate/20200109170101_add_twitter_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddTwitterUidToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :twitter_uid, :string
+  end
+end

--- a/db/migrate/20200111000000_create_services.rb
+++ b/db/migrate/20200111000000_create_services.rb
@@ -1,0 +1,16 @@
+class CreateServices < ActiveRecord::Migration[5.1]
+  def change
+    create_table "services", force: :cascade do |t|
+      t.string   "provider"
+      t.string   "uid"
+      t.integer  "user_id"
+      t.string   "uname"
+      t.string   "account_name"
+      t.string   "uemail"
+      t.datetime "created_at"
+      t.datetime "updated_at"
+    end
+
+    add_index "services", ["user_id"], name: "index_services_on_user_id", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_170101) do
+ActiveRecord::Schema.define(version: 2020_01_11_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,18 @@ ActiveRecord::Schema.define(version: 2020_01_09_170101) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["event_id"], name: "index_rooms_on_event_id"
+  end
+
+  create_table "services", force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.integer "user_id"
+    t.string "uname"
+    t.string "account_name"
+    t.string "uemail"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "session_formats", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_094054) do
+ActiveRecord::Schema.define(version: 2020_01_09_165645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,6 +245,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_094054) do
     t.datetime "remember_created_at"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "github_uid"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token"
     t.index ["email"], name: "index_users_on_email"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_165645) do
+ActiveRecord::Schema.define(version: 2020_01_09_170101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_165645) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "github_uid"
+    t.string "twitter_uid"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token"
     t.index ["email"], name: "index_users_on_email"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"


### PR DESCRIPTION
せっかく今までGitHubとTwitterのuid情報をDBに蓄えてたのにv2移行を機にデータがガサッと落ちてしまっていたのを可能な限りリストアしてみました。
これが無いと、レビュー時に参照できる情報量が少なくて困る、というのと、この先スピーカーをサイトに掲載するときにデータが足りなくて困る、という2つの困りごとがあったのでした。

## 今回の作業内容

1. v1のバックアップデータから services テーブルだけリストア。

1. https://rubykaigi.slack.com/archives/CBAP5CYHM/p1578584502163600
に書いたとおり、usersテーブルにgithub_uidとtwitter_uidをadd columnした。

1. servicesテーブルから、users.github_uid と users.twitter_uid にデータを移植
```
update users u set github_uid = s.uid from services s where u.id = s.user_id and s.provider = 'github';
UPDATE 559
update users u set twitter_uid = s.uid from services s where u.id = s.user_id and s.provider = 'twitter';
UPDATE 417
```

4. users.github_uid と users.twitter_uid のアクセッサをオーバーライドして、データが無い場合にはログイン情報から引っ張ってくるように変更。
これにより、両SNSのアカウントについてはv1のデータとv2のデータのORが取れるようになった。

ということで、情報共有のためぷるりの形を取ってはいるものの、実はここまで既にHerokuにはpush済みで本番DBで作業済みだったりします。

## 今後のTODO

1. github_uid, twitter_uidを登録、編集できる画面機能を作る
1. 足りてないデータ(特にv2で新しく登録してくれたスピーカーたちのtwitter_uid)を補完する
(最悪、今回のプロポーザルが通ったスピーカーたちの中の該当者に個別に聞く感じでもまあひとまずなんとかはなりそうな気はする)
1. 今回はログインのことはいったん置いておいたけど、v1同様に両方のアカウントでログインできるとベストだよねえ

/cc @asonas 