### PR TITLE
Takeout2021用にデザイン調整

### DIFF
--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -6,6 +6,25 @@ $bootstrap-sass-asset-helper: false !default;
 
 //== Colors
 //
+$color-base: #EBE0CE;
+$color-base-light: #F3EDE2;
+$color-main: #0B374D;
+$color-main-light: #545F64;
+$color-accent: #E14033;
+$color-link: #127CAE;
+$color-link-hover: #0092D8;
+$color-light-gray: #BFC6C9;
+
+// background
+$background-color: $color-base;
+
+// text
+$text-default: $color-main;
+$text-accent: $color-accent;
+$text-link: $color-link;
+$text-link-hover: $color-link-hover;
+
+
 //## Gray and brand colors for use across Bootstrap.
 $white: #fff;
 $black: #222;
@@ -44,14 +63,14 @@ $brand-gray:            #ccc;
 //## Settings for some of the most global styles.
 
 //** Background color for `<body>`.
-$body-bg:               #fff !default;
+$body-bg:               $background-color !default;
 //** Global text color on `<body>`.
-$text-color:            $gray-dark !default;
+$text-color:            $text-default !default;
 
 //** Global textual link color.
-$link-color:            $bright-blue !default;
+$link-color:            $text-link !default;
 //** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%) !default;
+$link-hover-color:      $text-link-hover !default;
 //** Link hover decoration.
 $link-hover-decoration: underline !default;
 
@@ -394,9 +413,9 @@ $navbar-padding-horizontal:        floor((30px / 2)) !default;
 $navbar-padding-vertical:          (($navbar-height - $line-height-computed) / 2) !default;
 $navbar-collapse-max-height:       340px !default;
 
-$navbar-default-color:             $black !default;
-$navbar-default-bg:                $pink !default;
-$navbar-default-border:            darken($navbar-default-bg, 2%) !default;
+$navbar-default-color:             $text-default !default;
+$navbar-default-bg:                $background-color !default;
+$navbar-default-border:            darken($background-color, 10%) !default;
 
 // Navbar links
 $navbar-default-link-color:                $black !default;
@@ -893,9 +912,9 @@ $blockquote-small-color:      $gray-light !default;
 //** Blockquote font size
 $blockquote-font-size:        ($font-size-base * 1.25) !default;
 //** Blockquote border color
-$blockquote-border-color:     $gray-lighter !default;
+$blockquote-border-color:     $color-base !default;
 //** Page header border color
-$page-header-border-color:    $gray-lighter !default;
+$page-header-border-color:    $color-base !default;
 //** Width of horizontal description list titles
 $dl-horizontal-offset:        $component-offset-horizontal !default;
 //** Point at which .dl-horizontal becomes horizontal

--- a/app/assets/stylesheets/modules/_navbar.scss
+++ b/app/assets/stylesheets/modules/_navbar.scss
@@ -54,10 +54,16 @@
 }
 
 .navbar-brand {
-  > img {
-  width: 150px;
+  font-family: 'Titillium Web', sans-serif;
+  font-size: 20px;
+  color: $text-default !important;
 }
+
+.navbar-default {
+  border-bottom: none;
+  box-shadow: 0 2px 2px rgba(0,0,0,0.2);
 }
+
 .nav {
   display: flex;
   align-items: center;

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       - if current_event
-        = link_to image_tag('rubykaigi2020_logo.png'), event_path(current_event), class: 'navbar-brand'
+        = link_to 'RubyKaigi Takeout 2021', event_path(current_event), class: 'navbar-brand'
       - else
         = link_to "CFP App", events_path, class: 'navbar-brand'
 


### PR DESCRIPTION
## このPRでやっていること
- カラー変更
- navbar のスタイル調整

## キャプチャ
![貼り付けた画像_2021_05_26_20_27](https://user-images.githubusercontent.com/4459676/119652191-bd7a9f80-be60-11eb-8920-a9289484a0d4.jpg)

## 相談
- レスポンシブ表示の時のメニューのborderとホバー時のbackgroundを消したいのですが、スタイルが効かずです https://github.com/ruby-no-kai/cfp-app/commit/d5bdc5fe446209fd1ada775a32ca768e1ac7f469

![貼り付けた画像_2021_05_26_20_56](https://user-images.githubusercontent.com/4459676/119655706-d9804000-be64-11eb-9bf8-dc20e85f909f.jpg)
