### PR TITLE
RubyKaigi 2026  用のデザイン

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -76,5 +76,5 @@
 @import "modules/teammates";
 @import "modules/staff-website-page";
 
-// override for RubyKaigi 2025
+// override for RubyKaigi 2026
 @import "override/index";

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -75,3 +75,6 @@
 @import "modules/widgets";
 @import "modules/teammates";
 @import "modules/staff-website-page";
+
+// override for RubyKaigi 2025
+@import "override/index";

--- a/app/assets/stylesheets/override/_base.scss
+++ b/app/assets/stylesheets/override/_base.scss
@@ -1,7 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Aoboshi+One&family=Lexend:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap');
-
 body {
-  font-family: $font-family-lexend;
   // background-color: $color-base;
   color: $color-main;
 }

--- a/app/assets/stylesheets/override/_base.scss
+++ b/app/assets/stylesheets/override/_base.scss
@@ -12,6 +12,10 @@ body[id*=admin_]{
   }
 }
 
+h1, h2, h3 {
+  font-family: $font-family-outfit;
+}
+
 .page-footer .page-footer-inner {
   border-top: solid 1px #f0e6e0;
 }

--- a/app/assets/stylesheets/override/_base.scss
+++ b/app/assets/stylesheets/override/_base.scss
@@ -1,5 +1,5 @@
 body {
-  // background-color: $color-base;
+  background-color: $body-bg;
   color: $color-main;
 }
 

--- a/app/assets/stylesheets/override/_base.scss
+++ b/app/assets/stylesheets/override/_base.scss
@@ -1,0 +1,36 @@
+@import url('https://fonts.googleapis.com/css2?family=Aoboshi+One&family=Lexend:wght@100..900&family=Noto+Sans+JP:wght@100..900&display=swap');
+
+body {
+  font-family: $font-family-lexend;
+  // background-color: $color-base;
+  color: $color-main;
+}
+
+body[id*=staff_],
+body[id*=admin_]{
+  background-color: white;
+  background-image: none;
+  .main {
+    font-family: "Montserrat", "Open Sans", Helvetica, Arial, sans-serif;
+  }
+}
+
+.page-footer .page-footer-inner {
+  border-top: solid 1px #f0e6e0;
+}
+
+input[type="text"],
+textarea,
+select,
+button.dropdown-toggle,
+.multiselect-container {
+  font-family: "Montserrat", "Open Sans", Helvetica, Arial, sans-serif;
+}
+
+.well {
+  background-color: rgba(white, .6);
+  border: none;
+  box-shadow: none;
+  margin-top: 16px;
+  border: solid 1px #e3e3e3;
+}

--- a/app/assets/stylesheets/override/_index.scss
+++ b/app/assets/stylesheets/override/_index.scss
@@ -1,0 +1,5 @@
+// Styles for RubyKaigi
+@import "override/variables";
+@import "override/base";
+@import "override/nav";
+@import "override/schedule";

--- a/app/assets/stylesheets/override/_nav.scss
+++ b/app/assets/stylesheets/override/_nav.scss
@@ -60,7 +60,7 @@
   font-family: 'Titillium Web', sans-serif;
   font-size: 20px;
   color: $text-default !important;
-  font-family: $font-family-lexend;
+  font-family: $font-family-sans-serif;
   font-weight: bold;
 }
 

--- a/app/assets/stylesheets/override/_nav.scss
+++ b/app/assets/stylesheets/override/_nav.scss
@@ -1,0 +1,121 @@
+.navbar-brand {
+  font-family: 'Titillium Web', sans-serif;
+  font-size: 20px;
+  color: $text-default !important;
+}
+
+.navbar-default {
+  border-bottom: none;
+  box-shadow: 0 2px 2px rgba(0,0,0,0.2);
+}
+
+
+
+
+
+
+.navbar-default {
+  background-color: $color-base;
+  border: none;
+  box-shadow: 0 2px 1px rgba(black, .1);
+}
+
+.navbar-default .navbar-nav > .active > a,
+.navbar-default .navbar-nav > .active > a:hover,
+.navbar-default .navbar-nav > .active > a:focus {
+  background-color: $color-main;
+  border-radius: 4px;
+}
+
+.navbar-default .navbar-nav > .open > a,
+.navbar-default .navbar-nav > .open > a:hover,
+.navbar-default .navbar-nav > .open > a:focus {
+  background-color: rgba($color-base, .1);
+  color: $color-base;
+}
+
+.navbar-nav > li:not(:first-child) {
+  padding-left: 12px;
+}
+
+.navbar-nav.session-counts .counts-container {
+  display: flex;
+}
+
+.navbar-nav.session-counts .counts-container .total {
+  font-size: 12px;
+  margin-right: 12px;
+}
+
+.navbar-fixed-top.program-subnav li > a,
+.navbar-fixed-top.schedule-subnav li > a {
+  height: 44px;
+  display: flex;
+  align-items: center;
+  i {
+    margin-right: .375em;
+  }
+}
+
+.navbar-nav.session-counts .counts-container .badge {
+  font-size: 12px;
+  padding: 3px 8px;
+  margin-left: 4px;
+}
+
+.navbar-brand {
+  color: $color-main;
+  font-family: $font-family-lexend;
+  font-weight: bold;
+}
+
+.navbar-fixed-top.program-subnav,
+.navbar-fixed-top.schedule-subnav {
+  border: none;
+  li.active {
+    border-bottom: none;
+    color: $color-base;
+  }
+}
+
+.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus {
+  background-color: $color-base;
+}
+
+.subnavbar .subnavbar-inner {
+  border-bottom: solid 1px #e0d6c7;
+}
+
+.download-link {
+  .glyphicon {
+    margin-right: .375em;
+  }
+}
+
+@media (min-width: $screen-md) {
+  .btn + .btn {
+    margin-left: 12px;
+  }
+}
+
+.btn-nav {
+  .page-header & {
+    margin-top: 10px;
+  }
+  .btn {
+    margin-right: 0;
+  }
+}
+
+@media (max-width: $screen-sm) {
+  .btn-github {
+    margin-left: 0;
+    margin-top: 8px;
+  }
+}
+
+@media (min-width: $screen-md) {
+  .navbar-nav__login {
+    margin-top: 6px;
+  }
+}

--- a/app/assets/stylesheets/override/_nav.scss
+++ b/app/assets/stylesheets/override/_nav.scss
@@ -4,6 +4,15 @@
   box-shadow: 0 2px 1px rgba(black, .1);
 }
 
+.navbar-default .navbar-nav li > a {
+  color: $color-main;
+}
+.navbar-default .navbar-nav > li > a:hover,
+.navbar-default .navbar-nav > li > a:focus {
+  background-color: rgba($color-main, .1);
+  color: $color-main;
+}
+
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
@@ -15,7 +24,7 @@
 .navbar-default .navbar-nav > .open > a:hover,
 .navbar-default .navbar-nav > .open > a:focus {
   background-color: rgba($color-base, .1);
-  color: $color-base;
+  color: $color-main;
 }
 
 .navbar-nav > li:not(:first-child) {

--- a/app/assets/stylesheets/override/_nav.scss
+++ b/app/assets/stylesheets/override/_nav.scss
@@ -1,19 +1,3 @@
-.navbar-brand {
-  font-family: 'Titillium Web', sans-serif;
-  font-size: 20px;
-  color: $text-default !important;
-}
-
-.navbar-default {
-  border-bottom: none;
-  box-shadow: 0 2px 2px rgba(0,0,0,0.2);
-}
-
-
-
-
-
-
 .navbar-default {
   background-color: $color-base;
   border: none;
@@ -64,7 +48,9 @@
 }
 
 .navbar-brand {
-  color: $color-main;
+  font-family: 'Titillium Web', sans-serif;
+  font-size: 20px;
+  color: $text-default !important;
   font-family: $font-family-lexend;
   font-weight: bold;
 }

--- a/app/assets/stylesheets/override/_schedule.scss
+++ b/app/assets/stylesheets/override/_schedule.scss
@@ -1,0 +1,55 @@
+.grid_container {
+  margin: 75px auto 0;
+}
+
+.grid_headers_wrapper {
+  .schedule_column_head {
+    width: 361px;
+  }
+}
+
+.track-select select {
+  color: $color-main;
+}
+
+.callout .btn {
+  margin-top: 10px;
+}
+
+.schedule_grid .nav_wrapper .schedule_nav {
+  padding-left: 0;
+  position: relative;
+  top: -8px;
+}
+
+.schedule_grid .nav_wrapper .schedule_nav li,
+.schedule_grid .nav_wrapper .schedule_nav li:hover,
+.schedule_grid .nav_wrapper .schedule_nav li.active {
+  border-radius: 16px;
+}
+
+.schedule_grid .nav_wrapper .schedule_nav li {
+  background-color: #eaeaea;
+  transition: all .2s ease-out;
+}
+
+.schedule_grid .nav_wrapper .schedule_nav li + li {
+  margin-left: 8px;
+}
+
+.schedule_grid .nav_wrapper .schedule_nav li.active {
+  border: none;
+  background-color: $color-accent;
+  pointer-events: none;
+  span:first-child {
+    color: $color-base;
+  }
+}
+
+.schedule_grid .nav_wrapper .schedule_nav li:hover {
+  background-color: #d1d1d1;
+}
+
+.datatable thead {
+  border-top: solid 1px #dddddd;
+}

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -1,59 +1,10 @@
-
 //== Colors
 //
-$color-base: #EBE0CE;
-$color-base-light: #F3EDE2;
-$color-main: #0B374D;
-$color-main-light: #545F64;
-$color-accent: #E14033;
-$color-link: #127CAE;
-$color-link-hover: #0092D8;
-$color-light-gray: #BFC6C9;
 $black: #222;
-$pink: #f3cadb;
-$lightpink: #fff8fb;
-$vividpink: #d84c85;
+$pink: #f3cadb;  // いる？
+$lightpink: #fff8fb;  // いる？
+$vividpink: #d84c85; // いる？
 
-// background
-$background-color: $color-base;
-
-// text
-$text-default: $color-main;
-$text-accent: $color-accent;
-$text-link: $color-link;
-$text-link-hover: $color-link-hover;
-
-$brand-primary:         $vividpink !default; //darken(#428bca, 6.5%) !default; // #337ab7
-
-$body-bg:               $background-color !default;
-$text-color:            $text-default !default;
-$link-color:            $text-link !default;
-$link-hover-color:      $text-link-hover !default;
-
-$font-family-lexend:  'Lexend', sans-serif, Helvetica, Arial, sans-serif !default;;
-$font-family-base:        $font-family-lexend !default;
-
-
-$navbar-default-color:             $text-default !default;
-$navbar-default-bg:                $background-color !default;
-$navbar-default-border:            darken($background-color, 10%) !default;
-
-
-$navbar-default-link-color:                $black !default;
-$navbar-default-link-hover-color:          $vividpink !default;
-
-
-$navbar-default-link-active-bg:            lighten($vividpink, 6.5%) !default;
-
-
-
-$blockquote-border-color:     $color-base !default;
-$page-header-border-color:    $color-base !default;
-
-
-/////////////////////////////////////////////////////
-// 2023
-// --------------------------------------------------
 $color-base: #F8F8F8;
 $color-base-light: #F3EDE2;
 $color-main: #333333;
@@ -66,10 +17,43 @@ $color-light-gray: #A8A6A9;
 $brand-primary: $color-accent;
 $brand-info-alt:#4E6994;
 
-$headings-font-weight: 600;
-$font-family-sans-serif:  'Montserrat', sans-serif;
-$font-family-lexend:  'Lexend', sans-serif;
+// background
+$background-color: $color-base;
 
-$navbar-default-link-active-bg: $color-accent;
+// text
+$text-default: $color-main;
+$text-accent: $color-accent;
+$text-link: $color-link;
+$text-link-hover: $color-link-hover;
+
+
+//== Scaffolding
+//
+$body-bg: $background-color !default;
+$text-color: $text-default !default;
+$link-color: $text-link !default;
+$link-hover-color: $text-link-hover !default;
+
+
+//== Typography
+//
+$font-family-sans-serif: 'Montserrat', sans-serif;
+$font-family-lexend: 'Lexend', sans-serif, Helvetica, Arial, sans-serif !default; // 2025 用なのであとで考える
+$font-family-lexend: 'Lexend', sans-serif;
+$font-family-base: $font-family-lexend !default;
+$headings-font-weight: 600;
+
+
+//== Navbar
+//
+$navbar-default-color: $text-default !default;
+$navbar-default-bg: $background-color !default;
+$navbar-default-border: darken($background-color, 10%) !default;
+$navbar-default-link-color: $black !default;
 $navbar-default-link-hover-color: $color-accent;
 $navbar-default-link-active-bg: lighten($color-accent, 6.5%);
+
+//== Type
+//
+$blockquote-border-color: $color-base !default;
+$page-header-border-color: $color-base !default;

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -35,6 +35,7 @@ $link-hover-color: $text-link-hover !default;
 //== Typography
 //
 $font-family-sans-serif: 'Montserrat', sans-serif;
+$font-family-outfit: 'Outfit', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 $font-family-base: $font-sans-serif !default;
 $headings-font-weight: 600;
 

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -15,7 +15,7 @@ $brand-primary: $color-accent;
 $brand-info-alt:#4E6994;
 
 // background
-$background-color: $color-base;
+$background-color: #F9EFEC;
 
 // text
 $text-default: $color-main;
@@ -26,7 +26,7 @@ $text-link-hover: $color-link-hover;
 
 //== Scaffolding
 //
-$body-bg: $background-color !default;
+$body-bg: $background-color;
 $text-color: $text-default !default;
 $link-color: $text-link !default;
 $link-hover-color: $text-link-hover !default;

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -35,9 +35,7 @@ $link-hover-color: $text-link-hover !default;
 //== Typography
 //
 $font-family-sans-serif: 'Montserrat', sans-serif;
-$font-family-lexend: 'Lexend', sans-serif, Helvetica, Arial, sans-serif !default; // 2025 用なのであとで考える
-$font-family-lexend: 'Lexend', sans-serif;
-$font-family-base: $font-family-lexend !default;
+$font-family-base: $font-sans-serif !default;
 $headings-font-weight: 600;
 
 

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -1,9 +1,6 @@
 //== Colors
 //
 $black: #222;
-$pink: #f3cadb;  // いる？
-$lightpink: #fff8fb;  // いる？
-$vividpink: #d84c85; // いる？
 
 $color-base: #F8F8F8;
 $color-base-light: #F3EDE2;

--- a/app/assets/stylesheets/override/_variables.scss
+++ b/app/assets/stylesheets/override/_variables.scss
@@ -1,0 +1,75 @@
+
+//== Colors
+//
+$color-base: #EBE0CE;
+$color-base-light: #F3EDE2;
+$color-main: #0B374D;
+$color-main-light: #545F64;
+$color-accent: #E14033;
+$color-link: #127CAE;
+$color-link-hover: #0092D8;
+$color-light-gray: #BFC6C9;
+$black: #222;
+$pink: #f3cadb;
+$lightpink: #fff8fb;
+$vividpink: #d84c85;
+
+// background
+$background-color: $color-base;
+
+// text
+$text-default: $color-main;
+$text-accent: $color-accent;
+$text-link: $color-link;
+$text-link-hover: $color-link-hover;
+
+$brand-primary:         $vividpink !default; //darken(#428bca, 6.5%) !default; // #337ab7
+
+$body-bg:               $background-color !default;
+$text-color:            $text-default !default;
+$link-color:            $text-link !default;
+$link-hover-color:      $text-link-hover !default;
+
+$font-family-lexend:  'Lexend', sans-serif, Helvetica, Arial, sans-serif !default;;
+$font-family-base:        $font-family-lexend !default;
+
+
+$navbar-default-color:             $text-default !default;
+$navbar-default-bg:                $background-color !default;
+$navbar-default-border:            darken($background-color, 10%) !default;
+
+
+$navbar-default-link-color:                $black !default;
+$navbar-default-link-hover-color:          $vividpink !default;
+
+
+$navbar-default-link-active-bg:            lighten($vividpink, 6.5%) !default;
+
+
+
+$blockquote-border-color:     $color-base !default;
+$page-header-border-color:    $color-base !default;
+
+
+/////////////////////////////////////////////////////
+// 2023
+// --------------------------------------------------
+$color-base: #F8F8F8;
+$color-base-light: #F3EDE2;
+$color-main: #333333;
+$color-main-light: #555555;
+$color-accent: #BA083D;
+$color-link: #1E4EC4;
+$color-link-hover: #0947AA;
+$color-light-gray: #A8A6A9;
+
+$brand-primary: $color-accent;
+$brand-info-alt:#4E6994;
+
+$headings-font-weight: 600;
+$font-family-sans-serif:  'Montserrat', sans-serif;
+$font-family-lexend:  'Lexend', sans-serif;
+
+$navbar-default-link-active-bg: $color-accent;
+$navbar-default-link-hover-color: $color-accent;
+$navbar-default-link-active-bg: lighten($color-accent, 6.5%);

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,7 @@
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
 
     .form-inputs
-      .col-sm-5.col-centered
+      .col-sm-8.col-md-6.col-lg-5.col-centered
         .well.clearfix
           = f.error_notification
           = f.input :email, required: false, autofocus: true, wrapper_html: {class: "col-sm-12"}
@@ -19,7 +19,7 @@
           .form-group= render "devise/shared/links"
 
       - unless Rails.env.production?
-        .col-sm-5.col-centered
+        .col-sm-8.col-md-6.col-lg-5.col-centered
           .well.clearfix
             .form-group
               = link_to 'Developer Login', '/users/auth/developer', class: 'btn btn-danger', method: :post

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       - if current_event
-        = link_to "RubyKaigi 2025", event_path(current_event), class: 'navbar-brand'
+        = link_to "RubyKaigi 2026", event_path(current_event), class: 'navbar-brand'
       - else
         = link_to "CFP App", events_path, class: 'navbar-brand'
 

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       - if current_event
-        = link_to "#{current_event.name} CFP", event_path(current_event), class: 'navbar-brand'
+        = link_to "RubyKaigi 2025", event_path(current_event), class: 'navbar-brand'
       - else
         = link_to "CFP App", events_path, class: 'navbar-brand'
 
@@ -58,7 +58,7 @@
 
       - else
         %ul.nav.navbar-nav.navbar-right
-          %li= link_to "Log in", new_user_session_path
+          %li.navbar-nav__login= link_to "Log in", new_user_session_path
 
 - if display_staff_event_subnav?
   = render partial: "layouts/nav/staff/event_subnav"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,9 +6,14 @@
 
     = stylesheet_link_tag 'application', media: 'all'
     = stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css', media: 'all'
-    = stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600"
 
     = stylesheet_pack_tag "application", media: 'all'
+
+    %link{rel:'preconnect', href:'//fonts.googleapis.com'}
+    %link{rel:'preconnect', href:'//fonts.gstatic.com', crossorigin: ''}
+    = stylesheet_link_tag '//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600'
+    = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap'
+
     = javascript_pack_tag "application"
 
     = javascript_include_tag 'https://www.gstatic.com/charts/loader.js'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,7 @@
     %link{rel:'preconnect', href:'//fonts.gstatic.com', crossorigin: ''}
     = stylesheet_link_tag '//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600'
     = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap'
+    = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap'
 
     = javascript_pack_tag "application"
 


### PR DESCRIPTION
**#33 のマージを先にお願いします！**

2026 用に背景色とフォントを変更しました。


Reason for Change
=================
* RubyKaigi 2026 のプロポーザル募集に向けてデザイン変更が必要

Changes
=======
* 年表記を 2025 から 2026 に変更した
* 背景色に #F9EFEC を反映した
* h1, h2, h3 相当の見出しに Outfit フォントを適用した

Minor
=====
*

https://github.com/ruby-no-kai/rubykaigi.org/issues/2889


### Screen shots

<img width="1067" height="957" alt="スクリーンショット 2025-11-18 14 45 46" src="https://github.com/user-attachments/assets/a368fb47-f532-4de2-ba50-6ef7062cd5d0" />
<img width="1067" height="923" alt="スクリーンショット 2025-11-18 14 46 13" src="https://github.com/user-attachments/assets/53c717de-f93c-4060-ae6b-92923e7158fe" />
<img width="1067" height="932" alt="スクリーンショット 2025-11-18 14 46 47" src="https://github.com/user-attachments/assets/209553ca-b5f1-40e2-9d03-f2519955a508" />
