### PR TITLE
Rubykaigi2026 design

### DIFF
--- a/app/assets/stylesheets/application.postcss.css
+++ b/app/assets/stylesheets/application.postcss.css
@@ -45,4 +45,6 @@
 @import "./modules/teammates.css";
 @import "./modules/staff-website-page.css";
 
+@import "./override/index.css";
+
 @import "tailwindcss/utilities";

--- a/app/assets/stylesheets/override/2026.css
+++ b/app/assets/stylesheets/override/2026.css
@@ -1,0 +1,9 @@
+/* For RubyKaigi 2026 */
+:root {
+  --body-bg: #F9EFEC;
+  --text-color: #000;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-family-outfit);
+}

--- a/app/assets/stylesheets/override/bootstrap.css
+++ b/app/assets/stylesheets/override/bootstrap.css
@@ -1,0 +1,56 @@
+/* Override navbar styles for RubyKaigi fork */
+.navbar-default {
+  background-color: var(--gray-lightest);
+  border: none;
+  box-shadow: 0 2px 1px var(--gray-light);
+}
+
+.navbar-default .navbar-brand,
+.navbar-default .navbar-nav .nav-link {
+  color: var(--text-color);
+}
+
+.navbar-default .navbar-brand:hover,
+.navbar-default .navbar-brand:focus,
+.navbar-default .navbar-brand:active,
+.navbar-default .navbar-nav .nav-link:hover,
+.navbar-default .navbar-nav .nav-link:focus,
+.navbar-default .navbar-nav .nav-link:active {
+  color: var(--gray-light);
+}
+
+.navbar-default .navbar-brand {
+  font-family: var(--font-family-sans-serif);
+  font-weight: bold;
+  padding-left: 0;
+}
+
+@media (min-width: 992px) {
+  .navbar-default .navbar-nav .nav-item.active .nav-link,
+  .navbar-default .navbar-nav .nav-item .nav-link.active {
+    background-color: var(--gray-dark) !important;
+    color: white;
+    border-radius: 4px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    margin-top: 7px;
+  }
+}
+
+@media (max-width: 991px) {
+  .navbar-default .navbar-nav .nav-item.active .nav-link,
+  .navbar-default .navbar-nav .nav-item .nav-link.active {
+    background-color: transparent;
+    color: var(--text-color);
+  }
+}
+
+.navbar-default .navbar-toggler{
+  border-color: var(--gray);
+  background-color: var(--gray);
+  color: var(--text-color);
+}
+
+.navbar-toggler:focus {
+  box-shadow: 0 0 0 2px;
+}

--- a/app/assets/stylesheets/override/index.css
+++ b/app/assets/stylesheets/override/index.css
@@ -1,3 +1,5 @@
 @import "./variables.css";
 @import "./layout.css";
 @import "./bootstrap.css";
+
+@import "./2026.css"

--- a/app/assets/stylesheets/override/index.css
+++ b/app/assets/stylesheets/override/index.css
@@ -1,0 +1,3 @@
+@import "./variables.css";
+@import "./layout.css";
+@import "./bootstrap.css";

--- a/app/assets/stylesheets/override/layout.css
+++ b/app/assets/stylesheets/override/layout.css
@@ -1,0 +1,4 @@
+body {
+  background-color: var(--body-bg);
+  color: var(--text-color);
+}

--- a/app/assets/stylesheets/override/variables.css
+++ b/app/assets/stylesheets/override/variables.css
@@ -1,0 +1,8 @@
+/* Override variables for RubyKaigi fork */
+:root {
+  --body-bg: white;
+  --gray-lightest: hsl(from var(--black) h s calc(l + 97));
+
+  --font-family-sans-serif: 'Montserrat', sans-serif;
+  --font-family-outfit: 'Outfit', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,7 +6,7 @@
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
 
     .form-inputs
-      .col-sm-5.col-centered
+      .col-sm-10.col-md-7.col-lg-6.col-centered
         .card
           .card-body
             = f.error_notification
@@ -20,7 +20,7 @@
             .form-group= render "devise/shared/links"
 
 - unless Rails.env.production?
-  .col-sm-5.col-centered.mt-3
+  .col-sm-10.col-md-7.col-lg-6.col-centered.mt-3
     .card
       .card-body
         .form-group

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -1,7 +1,7 @@
 .navbar.navbar-expand-lg.navbar-default.fixed-top
   .container-fluid
     - if current_event
-      = link_to "#{current_event.name} CFP", event_path(current_event), class: 'navbar-brand'
+      = link_to "RubyKaigi 2026", event_path(current_event), class: 'navbar-brand'
     - else
       = link_to "CFP App", events_path, class: 'navbar-brand'
     %button.navbar-toggler{ type: "button", data: { bs_toggle: "collapse", bs_target: ".navbar-collapse" }, aria: { controls: "navbarNav", expanded: "false", label: "Toggle navigation" } }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,11 @@
 
     = stylesheet_link_tag 'application', media: 'all'
     = stylesheet_link_tag '//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css', media: 'all'
+
+    %link{rel:'preconnect', href:'//fonts.googleapis.com'}
+    %link{rel:'preconnect', href:'//fonts.gstatic.com', crossorigin: ''}
     = stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600"
+    = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap'
 
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', type: 'module'
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,7 @@
     %link{rel:'preconnect', href:'//fonts.gstatic.com', crossorigin: ''}
     = stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600"
     = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap'
+    = stylesheet_link_tag '//fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap'
 
     = javascript_include_tag 'application', 'data-turbo-track': 'reload', type: 'module'
 


### PR DESCRIPTION
RubyKaigi 2025 までのスタイル変更を整理し 2026 のスタイルを反映しました。
下記のリトライです！

- #33
- #34

細かいところが反映しきれていない可能性があるので追加の修正があるかもしれません。

Reason for Change
=================
* upstream がメンテナンスされ Views が綺麗になったので RubyKaigi 向けのスタイル反映が再度必要
* 過去の RubyKaigi で行った調整を資産として活かしたい
* override/ に集約する形で upstream に追従しやすくする必要がある
* 来年以降のデザイン作業もカラースキーム変更に集中できるように整理したい

Changes
=======
* #33 を踏襲して `stylesheets/override/` に集約
  * ただし、目視確認できていない箇所はスタイルの移植をしていないので作業漏れがある場合は追加作業が必要
* #34 の作業を反映
  * 年表記を 2026 に変更した
  * 背景色に #F9EFEC を反映した
  * h1, h2, h3 相当の見出しに Outfit フォントを適用した

https://github.com/ruby-no-kai/rubykaigi.org/issues/2889

### ScreenShots 
<img width="1444" height="1288" alt="スクリーンショット 2025-12-14 17 44 54" src="https://github.com/user-attachments/assets/493b481e-d80c-4146-8e81-6dee87963a09" />
